### PR TITLE
add networking to the realm

### DIFF
--- a/bin/test-lkvm.bash
+++ b/bin/test-lkvm.bash
@@ -4,5 +4,4 @@
 #PWD=/ /workspaces/artifacts/cpu -namespace "/workspaces:/lib:/lib64:/usr:/bin:/etc:/home" $FVP_IP /workspaces/artifacts/lkvm run --realm --irqchip=gicv3-its --console=virtio \
 #    -c 1 -m 256 \
 #    -k /workspaces/artifacts/Image.guest -i /workspaces/artifacts/initramfs.cpio
-
-/mnt/workspaces/artifacts/lkvm run --realm --irqchip=gicv3-its --console=virtio -c 1 -m 256 -k /mnt/workspaces/artifacts/Image.guest -i /mnt/workspaces/artifacts/initramfs.cpio --9p /mnt,FM --rng
+/mnt/workspaces/artifacts/lkvm run --realm --irqchip=gicv3-its --console=virtio -c 1 -m 256 -k /mnt/workspaces/artifacts/Image.guest -i /mnt/workspaces/artifacts/initramfs.cpio --9p /mnt,FM --rng -p "ip=on"


### PR DESCRIPTION
Enables ip in the kernel command line for the realm.  This will provision the realm for user-space networking.