### PR TITLE
Prep for packaging within a vscode extension

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 		    libncurses-dev gawk flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf llvm \
         	      ca-certificates git-core openssh-client \
         	      libpopt-dev ncurses-dev automake autoconf git pkgconf \
-        	      lua5.1 liblua5.1-dev libmunge-dev libwrap0-dev libcap-dev libattr1-dev \
+        	      lua5.1 liblua5.1-dev libmunge-dev libwrap0-dev libcap-dev libattr1-dev libcap-ng-dev \
 		    mutt \
 		    pip \
             vim pinentry-tty libsasl2-modules \

--- a/Makefile
+++ b/Makefile
@@ -63,14 +63,6 @@ $(ARTIFACTS)/cpud:
 	make -C u-root-initramfs cpud
 
 $(ARTIFACTS)/qemu-system-aarch64:
-	docker build --platform arm64 -t $(CONTAINER_NAME)-qemu-builder qemu
-	docker run --platform arm64 --rm -i -t -v /var/run/docker.sock:/var/run/docker.sock -v $(VOLUME_NAME):/workspaces --workdir=/workspaces/cca-cpu $(CONTAINER_NAME)-qemu-builder:latest make qemu-build
-	sudo chown -Rf vscode.vscode $(ARTIFACTS)/qemu-system-aarch64
-	sudo chown -Rf vscode.vscode $(ARTIFACTS)/efi-virtio.rom
-	sudo chown -Rf vscode.vscode $(BUILDS_DIR)/qemu
-	sudo chown -Rf vscode.vscode $(SRC_DIR)/qemu
-
-qemu-build:
 	make -C qemu
 
 $(ARTIFACTS)/rmm.img: $(ARTIFACTS)

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(ARTIFACTS)/Image.guest: $(ARTIFACTS)
 	make -C linux-cca guest
 	cp $(BUILDS_DIR)/linux/guest/arch/arm64/boot/Image $(ARTIFACTS)/Image.guest
 
-$(ARTIFACTS)/Image: $(BUILDS_DIR)/linux/host/arch/arm64/boot/Image
+$(ARTIFACTS)/Image: $(ARTIFACTS)
 	make -C linux-cca host
 	cp -rf $(BUILDS_DIR)/linux/lib $(ARTIFACTS)
 	cp $(BUILDS_DIR)/linux/host/arch/arm64/boot/Image $(ARTIFACTS)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ make
 Once everything is built, you should be able to run the demo:
 
 ```
-vscode ➜ /workspaces/cca-cpu (fvp-cpu) $ bin/start-fvp.bash 
+vscode ➜ /workspaces/cca-cpu (fvp-cpu) $ bin/launch.bash 
 Starting FVP...hit ^a-d to exit
 ...
 [    3.723671] Freeing unused kernel memory: 7936K
@@ -76,34 +76,25 @@ Starting FVP...hit ^a-d to exit
    \__,_|    |_|  \___/ \___/ \__|
 
 [    3.837078] cgroup: Unknown subsys name 'net_cls'
-root@172:/# /workspaces/cca-cpu/bin/test-lkvm.bash
-  # lkvm run -k /mnt/workspaces/artifacts/Image.guest -m 256 -c 1 --name guest-150
-[    1.345860] cacheinfo: Unable to detect cache hierarchy for CPU 0
-[    1.453459] loop: module loaded
-[    1.457073] tun: Universal TUN/TAP device driver, 1.6
-[    1.497107] net eth0: Fail to set guest offload.
-[    1.498512] virtio_net virtio2 eth0: set_features() failed (-22); wanted 0x0000000000134829, left 0x0080000000134829
-[    1.523209] VFIO - User Level meta-driver version: 0.3
-[    1.531093] SMCCC: SOC_ID: ARCH_SOC_ID not implemented, skipping ....
-[    1.537293] NET: Registered PF_PACKET protocol family
-[    1.538770] 9pnet: Installing 9P2000 support
-[    1.558259] NET: Registered PF_VSOCK protocol family
-[    1.616972] registered taskstats version 1
-[    1.730594] Freeing unused kernel memory: 1088K
-[    1.733815] Run /init as init process
-1970/01/01 00:00:01 Welcome to u-root!
+Mounting namespace from host....
+starting Realm....be patient
+  # lkvm run -k /mnt/workspaces/artifacts/Image.guest -m 256 -c 1 --name guest-154
+... (about 30 seconds on an M1)
+[    2.400690] Freeing unused kernel memory: 1088K
+[    2.407718] Run /init as init process
+1970/01/01 00:00:02 Welcome to u-root!
                               _
    _   _      _ __ ___   ___ | |_
   | | | |____| '__/ _ \ / _ \| __|
   | |_| |____| | | (_) | (_) | |_
    \__,_|    |_|  \___/ \___/ \__|
 
-[    2.612950] cgroup: Unknown subsys name 'net_cls'
-root@(none):/# 
+[    2.723597] cgroup: Unknown subsys name 'net_cls'
+Mounting namespace from host....
+root@192:/# 
 ```
 
-The second invocation (test-lkvm) takes a couple minutes due to dialated simulation time.
-Both the FVP linux host (root@172 prompt) and the CCA realm (root@unknown) have the namespace
+The CCA realm (root@192) has the namespace of the originating dev container (or launch environment)
 from the originating vscode dev container mounted (this includes /workspaces, /home, as well
 as /usr, /bin, and /lib) -- so you can run all executables just like you would in your
 devcontainer.

--- a/bin/ccpu.bash
+++ b/bin/ccpu.bash
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-FVP_IP=`docker inspect fvp | jq -r '.[].NetworkSettings.IPAddress'`
-cpu -namespace "/workspaces:/lib:/lib64:/usr:/bin:/etc:/home" $FVP_IP $@

--- a/bin/launch.bash
+++ b/bin/launch.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo Starting FVP...hit ^a-d to exit
+docker run -d --rm --privileged --volumes-from `hostname` --name fvp -p 17010:17010 cca-cpu/fvp /workspaces/artifacts/cpud
+sleep 1
+echo Connect to FVP...
+FVP_IP=`docker inspect fvp | jq -r '.[].NetworkSettings.IPAddress'`
+/workspaces/artifacts/cpu -key /workspaces/artifacts/identity -namespace "/workspaces:/home" $FVP_IP /workspaces/cca-cpu/bin/start-fvp-cpud-stage2.bash
+echo Console terminated, cleaning up...
+docker kill fvp
+echo Done.

--- a/bin/namespace.elv
+++ b/bin/namespace.elv
@@ -4,6 +4,7 @@ var ns = [ "/workspaces" "/home" "/lib" "/usr" "/bin" "/etc" ]
 
 mount -t 9p -o trans=virtio,protocol=9p2000.L FM /mnt
 
+echo "Mounting namespace from host...."
 for p $ns {
     mkdir -p $p
     mount -t none -o bind /mnt$p $p
@@ -12,5 +13,6 @@ for p $ns {
 if ( > (count $args) 0 ) {  
     elvish -c $@args
 } else {
-    /bin/bash
+    echo starting Realm....be patient
+    /workspaces/cca-cpu/bin/start-lkvm.bash
 }

--- a/bin/start-fvp-cpud-stage2.bash
+++ b/bin/start-fvp-cpud-stage2.bash
@@ -43,7 +43,7 @@ screen -dmS FVP -t 'FVP' /tmp/local/opt/fvp/Base_RevC_AEMvA_pkg/models/Linux64*/
 		-C pctl.startup=0.0.0.0 \
 		-C bp.smsc_91c111.enabled=1 \
 		-C bp.hostbridge.userNetworking=1 \
-		-C bp.hostbridge.userNetPorts=17010=17010 \
+		-C bp.hostbridge.userNetPorts=17011=17011 \
 		-C bp.pl011_uart0.uart_enable=1 \
 		-C bp.pl011_uart1.uart_enable=1 \
 		-C bp.pl011_uart2.uart_enable=1 \

--- a/bin/start-lkvm.bash
+++ b/bin/start-lkvm.bash
@@ -1,0 +1,3 @@
+#!/bbin/elvish
+
+/mnt/workspaces/artifacts/lkvm run --realm --irqchip=gicv3-its --console=virtio -c 1 -m 256 -k /mnt/workspaces/artifacts/Image.guest -i /mnt/workspaces/artifacts/initramfs.cpio --9p /mnt,FM --rng -p "ip=on uroot.uinitargs=/bin/bash"

--- a/bin/test-qemu.bash
+++ b/bin/test-qemu.bash
@@ -4,9 +4,10 @@
     -object rng-random,filename=/dev/urandom,id=rng0 \
     -device virtio-rng-pci,rng=rng0 \
     -device virtio-serial-pci,id=virtio-serial0 -chardev stdio,id=charconsole0 \
+    -device virtio-net-pci,netdev=n1 \
+    -netdev user,id=n1,hostfwd=tcp:127.0.0.1:17010-:17010,net=192.168.1.0/24,host=192.168.1.1 \
     -fsdev local,security_model=passthrough,id=fsdev0,path=/mnt \
     -device virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=FM \
     -device virtconsole,chardev=charconsole0,id=console0 -overcommit mem-lock=on -nodefaults
 
-#    -device virtio-net-pci,netdev=n1 \
-#    -netdev user,id=n1,hostfwd=tcp:127.0.0.1:17010-:17010,net=192.168.1.0/24,host=192.168.1.1 \
+

--- a/qemu/Makefile
+++ b/qemu/Makefile
@@ -8,7 +8,7 @@ QEMU_SRC = $(SRC_DIR)/qemu
 QEMU_BUILD = $(BUILDS_DIR)/qemu
 QEMU_URL = git://jpbrucker.net/jbru/qemu.git
 QEMU_BRANCH = cca/rfc-v1
-QEMU_CONFIGURE_FLAGS = --target-list=aarch64-softmmu --static --disable-docs
+QEMU_CONFIGURE_FLAGS = --target-list=aarch64-softmmu --disable-docs --enable-slirp --enable-virtfs
 
 default: build
 

--- a/u-root-initramfs/0001-Weird-cast-error-seems-to-cause-trouble.patch
+++ b/u-root-initramfs/0001-Weird-cast-error-seems-to-cause-trouble.patch
@@ -1,0 +1,29 @@
+From bdc2940825d8eb827bc3136a822e10ad201ba453 Mon Sep 17 00:00:00 2001
+From: Eric Van Hensbergen <ericvh@kernel.org>
+Date: Sat, 6 May 2023 16:34:41 +0000
+Subject: [PATCH] Weird cast error seems to cause trouble
+
+This seems to generative invalid argument errors
+in my setup, not sure why this doesn't show up elsewhere.
+
+Signed-off-by: Eric Van Hensbergen <ericvh@kernel.org>
+---
+ client/cpu_linux.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/client/cpu_linux.go b/client/cpu_linux.go
+index f2ed9d8..214ae6f 100644
+--- a/client/cpu_linux.go
++++ b/client/cpu_linux.go
+@@ -12,7 +12,7 @@ import (
+ )
+ 
+ func osflags(fi os.FileInfo, mode p9.OpenFlags) int {
+-	flags := int(mode)
++	flags := mode.OSFlags()
+ 	if fi.IsDir() {
+ 		flags |= syscall.O_DIRECTORY
+ 	}
+-- 
+2.34.1
+

--- a/u-root-initramfs/Makefile
+++ b/u-root-initramfs/Makefile
@@ -6,6 +6,7 @@ include ../common.mk
 
 $(SRC_DIR)/cpu/.git:
 	git clone --depth 1 https://github.com/u-root/cpu.git $(SRC_DIR)/cpu
+	patch -N -p 1 -d $(SRC_DIR)/cpu -i $(ROOTDIR)/cca-cpu/u-root-initramfs/0001-Weird-cast-error-seems-to-cause-trouble.patch
 
 $(ARTIFACTS)/cpu: $(SRC_DIR)/cpu/.git
 	cd $(SRC_DIR)/cpu && go build -o $(ARTIFACTS)/cpu $(SRC_DIR)/cpu/cmds/cpu/.


### PR DESCRIPTION
Change launch config around a bit to automate launch of CCA realm a bit more, and switch to using cpu to launch FVP so that we get the originating namespace instead of the FVP container namespace.